### PR TITLE
Add partial JavaScript port of recept

### DIFF
--- a/bar.js
+++ b/bar.js
@@ -1,0 +1,68 @@
+// JavaScript port of bar.py
+const defaultBarSize = 14;
+
+function bar(n, d, s = defaultBarSize, left = false) {
+  try {
+    let mn = Math.max(0, Math.min(n, d));
+    if (left) {
+      mn = d - mn;
+    }
+    const sn = mn * s / d;
+    const si = Math.floor(sn);
+    let sr = sn % 1;
+
+    let s1, s2, s3;
+    if (left) {
+      s1 = ' '.repeat(si);
+      s3 = '#'.repeat(s - si - 1);
+      sr = (1.0 - sr) % 1;
+    } else {
+      s1 = '#'.repeat(si);
+      s3 = ' '.repeat(s - si - 1);
+    }
+
+    if (si < s) {
+      const idx = Math.floor(sr * 4);
+      s2 = [' ', '-', '+', '='][idx];
+    } else {
+      s2 = '';
+    }
+    return `${s1}${s2}${s3}`;
+  } catch (e) {
+    return ' '.repeat(s);
+  }
+}
+
+function barLog(n, d, s = defaultBarSize, base = Math.E, start = 1.0, left = false) {
+  try {
+    const logBase = Math.log(base);
+    return bar(Math.log(start + n) / logBase, Math.log(start + d) / logBase, s, left);
+  } catch (e) {
+    return ' '.repeat(s);
+  }
+}
+
+function signedBar(n, d, s = defaultBarSize / 2) {
+  if (n >= 0.0) {
+    return ' '.repeat(s) + '|' + bar(n, d, s);
+  } else {
+    return bar(-n, d, s, true) + '|' + ' '.repeat(s);
+  }
+}
+
+function signedBarLog(n, d, s = defaultBarSize / 2, base = Math.E, start = 1.0) {
+  if (n > 0.0) {
+    return ' '.repeat(s) + '|' + barLog(n, d, s, base, start);
+  } else if (n < 0.0) {
+    return barLog(-n, d, s, base, start, true) + '|' + ' '.repeat(s);
+  } else {
+    return ' '.repeat(s) + '|' + ' '.repeat(s);
+  }
+}
+
+module.exports = {
+  bar,
+  barLog,
+  signedBar,
+  signedBarLog,
+};

--- a/complex.js
+++ b/complex.js
@@ -1,0 +1,46 @@
+// Simple Complex number helper class
+class Complex {
+  constructor(re = 0, im = 0) {
+    this.re = re;
+    this.im = im;
+  }
+
+  static fromPolar(r, tau) {
+    const rad = tau * 2 * Math.PI;
+    return new Complex(r * Math.cos(rad), r * Math.sin(rad));
+  }
+
+  add(other) {
+    return new Complex(this.re + other.re, this.im + other.im);
+  }
+
+  sub(other) {
+    return new Complex(this.re - other.re, this.im - other.im);
+  }
+
+  mul(other) {
+    return new Complex(
+      this.re * other.re - this.im * other.im,
+      this.re * other.im + this.im * other.re
+    );
+  }
+
+  div(other) {
+    const denom = other.re * other.re + other.im * other.im;
+    if (denom === 0) return new Complex(0, 0);
+    return new Complex(
+      (this.re * other.re + this.im * other.im) / denom,
+      (this.im * other.re - this.re * other.im) / denom
+    );
+  }
+
+  abs() {
+    return Math.hypot(this.re, this.im);
+  }
+
+  toString() {
+    return `${this.re}+${this.im}j`;
+  }
+}
+
+module.exports = Complex;

--- a/recept.js
+++ b/recept.js
@@ -1,0 +1,279 @@
+// JavaScript port of recept.py. This is a partial port focusing on the
+// signal processing utilities used by other modules.
+
+const bar = require('./bar.js');
+const tau = require('./tau.js');
+const Complex = require('./complex.js');
+
+function complexDelta(cval, priorCval) {
+  if (priorCval.re !== 0 || priorCval.im !== 0) {
+    return cval.div(priorCval);
+  } else {
+    return new Complex(0, 0);
+  }
+}
+
+class ExponentialSmoother {
+  constructor(initialValue = 0.0) {
+    this.v = initialValue;
+  }
+  sample(value, factor) {
+    this.v += (value - this.v) / factor;
+    return this.v;
+  }
+  toString() {
+    return this.v.toFixed(3);
+  }
+}
+
+class ExponentialSmoothing {
+  constructor(windowSize, initialValue = 0.0) {
+    this.w = windowSize;
+    this.v = new ExponentialSmoother(initialValue);
+  }
+  sample(value) {
+    return this.v.sample(value, this.w);
+  }
+  toString() {
+    return `{ave=${this.v}, window=${this.w.toFixed(3)}}`;
+  }
+}
+
+class Delta {
+  constructor(priorSequence = null) {
+    this.prior_sequence = priorSequence;
+  }
+  sample(sequenceValue) {
+    let deltaValue = null;
+    if (this.prior_sequence !== null) {
+      deltaValue = sequenceValue - this.prior_sequence;
+    }
+    this.prior_sequence = sequenceValue;
+    return deltaValue;
+  }
+}
+
+class PhaseDelta {
+  constructor(priorAngle = null) {
+    this.prior_angle = priorAngle; // Complex number
+  }
+  sample(angleValue) {
+    let deltaValue = null;
+    if (this.prior_angle) {
+      deltaValue = complexDelta(angleValue, this.prior_angle);
+    }
+    this.prior_angle = angleValue;
+    return deltaValue;
+  }
+}
+
+class Distribution {
+  constructor(initialValue = 0.0, priorSequence = 0.0) {
+    this.ave = new ExponentialSmoother(initialValue);
+    this.dev = new ExponentialSmoother(priorSequence);
+  }
+  sample(value, factor) {
+    const deviation = Math.abs(this.ave.v - value);
+    this.ave.sample(value, factor);
+    this.dev.sample(deviation, factor);
+    return this.dist();
+  }
+  dist() {
+    return [this.ave.v, this.dev.v];
+  }
+  toString() {
+    const [a, d] = this.dist();
+    return `{mean=${a.toFixed(3)} dev=${d.toFixed(3)}}`;
+  }
+}
+
+class WeightedDistribution extends Distribution {
+  constructor(windowSize = 1.0, initialValue = 0.0, priorSequence = null) {
+    super(initialValue, priorSequence);
+    this.w = windowSize;
+  }
+  sample(value) {
+    return super.sample(value, this.w);
+  }
+}
+
+class Apex extends Delta {
+  constructor(priorValue = null) {
+    super(priorValue);
+    this.prior_is_positive = true;
+  }
+  sample(value) {
+    const d = super.sample(value);
+    const is_positive = d >= 0;
+    if (this.prior_is_positive !== is_positive) {
+      this.prior_is_positive = is_positive;
+      return value;
+    }
+    return null;
+  }
+}
+
+class TimeApex {
+  constructor(priorValue = null, priorSequence = null) {
+    this.apex = new Apex(priorValue);
+    this.delta = new Delta(priorSequence);
+  }
+  sample(time, value) {
+    const apex = this.apex.sample(value);
+    if (apex === null) {
+      return [null, null];
+    } else {
+      return [apex, this.delta.sample(time)];
+    }
+  }
+}
+
+class SignDelta {
+  constructor(priorValue = null) {
+    this.prior_value = priorValue;
+  }
+  sampleCmp(value) {
+    const s = Math.sign(value - this.prior_value);
+    this.prior_value = value;
+    return s;
+  }
+  sampleStart(value) {
+    return this.sampleCmp(value) === 1;
+  }
+  sampleStop(value) {
+    return this.sampleCmp(value) === -1;
+  }
+}
+
+class Sign {
+  static sample(value) {
+    return value > 0;
+  }
+}
+
+class DynamicWindow {
+  constructor(targetDuration, windowSize, priorValue = null, initialDuration = 0.0) {
+    this.td = targetDuration;
+    this.s = new Delta(priorValue);
+    this.ed = new ExponentialSmoothing(windowSize, initialDuration);
+  }
+  sample(sequenceValue) {
+    const duration_since = this.s.sample(sequenceValue);
+    if (duration_since === null) {
+      return this.td;
+    }
+    const expected_duration = this.ed.sample(duration_since);
+    return this.td / expected_duration;
+  }
+  toString() {
+    const w = (this.ed.v.v > 0.0) ? (this.td / this.ed.v.v) : 0.0;
+    return `{window=${w.toFixed(3)}, duration=${this.ed}, target=${this.td}}`;
+  }
+}
+
+class SmoothDuration {
+  constructor(targetDuration, windowSize, priorValue = null, initialDuration = 0.0, initialValue = 0.0) {
+    this.dw = new DynamicWindow(targetDuration, windowSize, priorValue, initialDuration);
+    this.v = new ExponentialSmoother(initialValue);
+  }
+  sample(value, sequenceValue) {
+    const w = this.dw.sample(sequenceValue);
+    return this.v.sample(value, w);
+  }
+  toString() {
+    return `{ave=${this.v}. window=${this.dw}}`;
+  }
+}
+
+class SmoothDurationDistribution {
+  constructor(targetDuration, windowSize, priorValue = null, initialDuration = 0.0, initialValue = 0.0, priorSequence = 0.0) {
+    this.dw = new DynamicWindow(targetDuration, windowSize, priorValue, initialDuration);
+    this.v = new Distribution(initialValue, priorSequence);
+  }
+  sample(value, sequenceValue) {
+    const w = this.dw.sample(sequenceValue);
+    return this.v.sample(value, w);
+  }
+  toString() {
+    return `{dist=${this.v}, window=${this.dw}}`;
+  }
+}
+
+class TimeSmoothing {
+  constructor(period, phase, windowFactor = 1.0, initialValue = new Complex(0, 0)) {
+    this.period = period;
+    this.phase = phase;
+    this.v = new ExponentialSmoother(initialValue);
+    this.wf = windowFactor;
+  }
+  sample(time, value) {
+    const rect = tau.rect((time + this.phase) / this.period);
+    const val = new Complex(value, 0).mul(new Complex(rect.re, rect.im));
+    const cval = this.v.sample(val, this.period * this.wf);
+    return [1.0, cval];
+  }
+}
+
+class DynamicTimeSmoothing extends TimeSmoothing {
+  constructor(period, phase, windowFactor = 1.0, initialValue = new Complex(0, 0), initialDelta = 0.0) {
+    super(period, phase, windowFactor, initialValue);
+    this.glissando = new ExponentialSmoother(initialDelta);
+  }
+  updatePeriod(period) {
+    const glissando_value = this.glissando.sample(period - this.period, period * this.wf);
+    this.phase = (this.phase / this.period) * period;
+    this.period = period;
+    return glissando_value;
+  }
+  updatePhase(phase) {
+    this.phase = phase;
+  }
+  sample(time, value, period = null) {
+    let glissando_value;
+    if (period !== null) {
+      glissando_value = this.updatePeriod(period);
+    } else {
+      glissando_value = this.glissando.v;
+    }
+    const [delta, time_value] = super.sample(time, value);
+    return [delta, time_value, glissando_value];
+  }
+}
+
+class ApexTimeSmoothing extends DynamicTimeSmoothing {
+  constructor(period, phase, windowFactor = 1.0, initialValue = new Complex(0, 0), initialDelta = 0.0, priorValue = null, priorSequence = null) {
+    super(period, phase, windowFactor, initialValue, initialDelta);
+    this.time_apex = new TimeApex(priorValue, priorSequence);
+  }
+  sample(time, value, period = null) {
+    const glissando_value = period !== null ? this.updatePeriod(period) : this.glissando.v;
+    const [apex, time_delta] = this.time_apex.sample(time, value);
+    if (apex !== null) {
+      const td = time_delta === null ? 1.0 : time_delta;
+      const rect = tau.rect((time + this.phase) / this.period);
+      const cval = this.v.sample(new Complex(value, 0).mul(new Complex(rect.re, rect.im)), this.period * this.wf);
+      return [td, cval, glissando_value];
+    }
+    return [null, null, null];
+  }
+}
+
+module.exports = {
+  complexDelta,
+  ExponentialSmoother,
+  ExponentialSmoothing,
+  Delta,
+  PhaseDelta,
+  Distribution,
+  WeightedDistribution,
+  Apex,
+  TimeApex,
+  SignDelta,
+  Sign,
+  DynamicWindow,
+  SmoothDuration,
+  SmoothDurationDistribution,
+  TimeSmoothing,
+  DynamicTimeSmoothing,
+  ApexTimeSmoothing,
+};

--- a/tau.js
+++ b/tau.js
@@ -1,0 +1,30 @@
+// JavaScript port of tau.py - works in tau units instead of radians.
+const radianCycle = Math.PI * 2;
+
+function rad2tau(mag, rad) {
+  return [mag, ((rad / radianCycle) + 0.5) % 1 - 0.5];
+}
+
+function tau2rad(mag, tau) {
+  return [mag, tau * radianCycle];
+}
+
+function rect(period, mag = 1) {
+  const [m, rad] = tau2rad(mag, period);
+  return { re: Math.cos(rad) * m, im: Math.sin(rad) * m };
+}
+
+function polar(cval) {
+  const mag = Math.sqrt(cval.re * cval.re + cval.im * cval.im);
+  const rad = Math.atan2(cval.im, cval.re);
+  const [, tau] = rad2tau(mag, rad);
+  return [mag, tau];
+}
+
+module.exports = {
+  rad2tau,
+  tau2rad,
+  rect,
+  polar,
+  radianCycle,
+};


### PR DESCRIPTION
## Summary
- port parts of `recept.py` to JavaScript as `recept.js`
- create helper modules `tau.js`, `bar.js`, and `complex.js` mirroring Python utilities

## Testing
- `node -e "require('./recept.js');"`

------
https://chatgpt.com/codex/tasks/task_e_686effe1de3883338541954790154448