### PR TITLE
Fix AudioWorklet imports

### DIFF
--- a/bar.js
+++ b/bar.js
@@ -1,7 +1,7 @@
 // JavaScript port of bar.py
 const defaultBarSize = 14;
 
-function bar(n, d, s = defaultBarSize, left = false) {
+export function bar(n, d, s = defaultBarSize, left = false) {
   try {
     let mn = Math.max(0, Math.min(n, d));
     if (left) {
@@ -33,7 +33,7 @@ function bar(n, d, s = defaultBarSize, left = false) {
   }
 }
 
-function barLog(n, d, s = defaultBarSize, base = Math.E, start = 1.0, left = false) {
+export function barLog(n, d, s = defaultBarSize, base = Math.E, start = 1.0, left = false) {
   try {
     const logBase = Math.log(base);
     return bar(Math.log(start + n) / logBase, Math.log(start + d) / logBase, s, left);
@@ -42,7 +42,7 @@ function barLog(n, d, s = defaultBarSize, base = Math.E, start = 1.0, left = fal
   }
 }
 
-function signedBar(n, d, s = defaultBarSize / 2) {
+export function signedBar(n, d, s = defaultBarSize / 2) {
   if (n >= 0.0) {
     return ' '.repeat(s) + '|' + bar(n, d, s);
   } else {
@@ -50,7 +50,7 @@ function signedBar(n, d, s = defaultBarSize / 2) {
   }
 }
 
-function signedBarLog(n, d, s = defaultBarSize / 2, base = Math.E, start = 1.0) {
+export function signedBarLog(n, d, s = defaultBarSize / 2, base = Math.E, start = 1.0) {
   if (n > 0.0) {
     return ' '.repeat(s) + '|' + barLog(n, d, s, base, start);
   } else if (n < 0.0) {
@@ -60,9 +60,3 @@ function signedBarLog(n, d, s = defaultBarSize / 2, base = Math.E, start = 1.0) 
   }
 }
 
-module.exports = {
-  bar,
-  barLog,
-  signedBar,
-  signedBarLog,
-};

--- a/complex.js
+++ b/complex.js
@@ -1,5 +1,5 @@
 // Simple Complex number helper class
-class Complex {
+export default class Complex {
   constructor(re = 0, im = 0) {
     this.re = re;
     this.im = im;
@@ -43,4 +43,3 @@ class Complex {
   }
 }
 
-module.exports = Complex;

--- a/recept.js
+++ b/recept.js
@@ -1,9 +1,9 @@
 // JavaScript port of recept.py. This is a partial port focusing on the
 // signal processing utilities used by other modules.
 
-const bar = require('./bar.js');
-const tau = require('./tau.js');
-const Complex = require('./complex.js');
+import * as bar from './bar.js';
+import * as tau from './tau.js';
+import Complex from './complex.js';
 
 function complexDelta(cval, priorCval) {
   if (priorCval.re !== 0 || priorCval.im !== 0) {
@@ -258,7 +258,7 @@ class ApexTimeSmoothing extends DynamicTimeSmoothing {
   }
 }
 
-module.exports = {
+export {
   complexDelta,
   ExponentialSmoother,
   ExponentialSmoothing,

--- a/tau.js
+++ b/tau.js
@@ -1,30 +1,23 @@
 // JavaScript port of tau.py - works in tau units instead of radians.
-const radianCycle = Math.PI * 2;
+export const radianCycle = Math.PI * 2;
 
-function rad2tau(mag, rad) {
+export function rad2tau(mag, rad) {
   return [mag, ((rad / radianCycle) + 0.5) % 1 - 0.5];
 }
 
-function tau2rad(mag, tau) {
+export function tau2rad(mag, tau) {
   return [mag, tau * radianCycle];
 }
 
-function rect(period, mag = 1) {
+export function rect(period, mag = 1) {
   const [m, rad] = tau2rad(mag, period);
   return { re: Math.cos(rad) * m, im: Math.sin(rad) * m };
 }
 
-function polar(cval) {
+export function polar(cval) {
   const mag = Math.sqrt(cval.re * cval.re + cval.im * cval.im);
   const rad = Math.atan2(cval.im, cval.re);
   const [, tau] = rad2tau(mag, rad);
   return [mag, tau];
 }
 
-module.exports = {
-  rad2tau,
-  tau2rad,
-  rect,
-  polar,
-  radianCycle,
-};

--- a/uke-worklet.js
+++ b/uke-worklet.js
@@ -1,25 +1,8 @@
 // AudioWorkletProcessor for ukulele string detection using recept.js primitives
 
-function loadModule(url) {
-  // `self` is the global object inside an AudioWorkletProcessor but it may not
-  // be defined if this script is executed in another environment (e.g. Node).
-  const g = typeof self !== 'undefined' ? self : globalThis;
-
-  const prevModule = g.module;
-  const prevExports = g.exports;
-  g.module = { exports: {} };
-  g.exports = g.module.exports;
-  importScripts(url);
-  const exports = g.module.exports;
-  g.module = prevModule;
-  g.exports = prevExports;
-  return exports;
-}
-
-const Complex = loadModule('complex.js');
-const tau = loadModule('tau.js');
-const recept = loadModule('recept.js');
-const { ExponentialSmoother, TimeSmoothing } = recept;
+import Complex from './complex.js';
+import * as tau from './tau.js';
+import { ExponentialSmoother, TimeSmoothing } from './recept.js';
 
 class Lifecycle {
   constructor(max_r = 1.0) {


### PR DESCRIPTION
## Summary
- convert helper scripts to ES modules
- import helpers directly in `uke-worklet.js`

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686f0994d1f483339b6dd427eb313c91