### PR TITLE
Extend tuner output fields

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,17 +2,66 @@
 
 const output = document.getElementById('output');
 const header = document.getElementById('header');
-header.textContent = 'note          F         entropy    -energy      phase     amplitude   onset-amp      cycle';
+header.textContent =
+  '  free energy       entropy        - energy          phase      amplitude      onset-amp           cycle';
 
-function bar(n, d, size = 14) {
-  const mn = Math.max(0, Math.min(n, d));
-  const sn = mn * size / d;
-  const si = Math.floor(sn);
-  const sr = sn % 1;
-  const s1 = '#'.repeat(si);
-  const s3 = ' '.repeat(size - si - 1);
-  const s2 = si < size ? [' ', '-', '+', '='][Math.floor(sr * 4)] : '';
-  return s1 + s2 + s3;
+function bar(n, d, size = 14, left = false) {
+  try {
+    let mn = Math.max(0, Math.min(n, d));
+    if (left) {
+      mn = d - mn;
+    }
+    const sn = mn * size / d;
+    const si = Math.floor(sn);
+    let sr = sn % 1;
+    let s1, s2, s3;
+    if (left) {
+      s1 = ' '.repeat(si);
+      s3 = '#'.repeat(size - si - 1);
+      sr = (1.0 - sr) % 1;
+    } else {
+      s1 = '#'.repeat(si);
+      s3 = ' '.repeat(size - si - 1);
+    }
+    if (si < size) {
+      s2 = [' ', '-', '+', '='][Math.floor(sr * 4)];
+    } else {
+      s2 = '';
+    }
+    return `${s1}${s2}${s3}`;
+  } catch (e) {
+    return ' '.repeat(size);
+  }
+}
+
+function barLog(n, d, size = 14, base = Math.E, start = 1.0, left = false) {
+  try {
+    const logBase = Math.log(base);
+    return bar(Math.log(start + n) / logBase,
+               Math.log(start + d) / logBase,
+               size,
+               left);
+  } catch (e) {
+    return ' '.repeat(size);
+  }
+}
+
+function signedBar(n, d, size = 7) {
+  if (n >= 0.0) {
+    return ' '.repeat(size) + '|' + bar(n, d, size);
+  } else {
+    return bar(-n, d, size, true) + '|' + ' '.repeat(size);
+  }
+}
+
+function signedBarLog(n, d, size = 7, base = Math.E, start = 1.0) {
+  if (n > 0.0) {
+    return ' '.repeat(size) + '|' + barLog(n, d, size, base, start);
+  } else if (n < 0.0) {
+    return barLog(-n, d, size, base, start, true) + '|' + ' '.repeat(size);
+  } else {
+    return ' '.repeat(size) + '|' + ' '.repeat(size);
+  }
 }
 
 if (navigator.mediaDevices) {
@@ -27,10 +76,14 @@ if (navigator.mediaDevices) {
         let lines = '';
         for (let i = 0; i < vals.length; i++) {
           const v = vals[i];
-          lines += `${names[i]} F:${v.F.toFixed(4)} E:${v.entropy.toFixed(4)} ` +
-                   `NE:${v.neg_energy.toFixed(4)} P:${v.phase.toFixed(4)} ` +
-                   `A:${v.amp.toFixed(4)} O:${v.onset_amp.toFixed(4)} ` +
-                   `C:${v.cycle.toFixed(4)}\n`;
+          lines += `${names[i]} ` +
+                   `${signedBarLog(v.F, 1.0)} ` +
+                   `${signedBarLog(v.entropy, 1.0)} ` +
+                   `${signedBarLog(v.neg_energy, 1.0)} ` +
+                   `${signedBar(v.phase, 0.5)} ` +
+                   `${barLog(v.amp, 1.0)} ` +
+                   `${barLog(v.onset_amp, 1.0)} ` +
+                   `${(-v.cycle).toFixed(3).padStart(10)}\n`;
         }
         output.textContent = lines;
       };

--- a/main.js
+++ b/main.js
@@ -1,6 +1,8 @@
 // Main thread script for uke tuner demo
 
 const output = document.getElementById('output');
+const header = document.getElementById('header');
+header.textContent = 'note          F         entropy    -energy      phase     amplitude   onset-amp      cycle';
 
 function bar(n, d, size = 14) {
   const mn = Math.max(0, Math.min(n, d));
@@ -24,8 +26,11 @@ if (navigator.mediaDevices) {
         const names = ['C4', 'E4', 'G4', 'A4'];
         let lines = '';
         for (let i = 0; i < vals.length; i++) {
-          const F = vals[i].F;
-          lines += `${names[i]} F:${F.toFixed(4)} ${bar(Math.abs(F), 1.0)}\n`;
+          const v = vals[i];
+          lines += `${names[i]} F:${v.F.toFixed(4)} E:${v.entropy.toFixed(4)} ` +
+                   `NE:${v.neg_energy.toFixed(4)} P:${v.phase.toFixed(4)} ` +
+                   `A:${v.amp.toFixed(4)} O:${v.onset_amp.toFixed(4)} ` +
+                   `C:${v.cycle.toFixed(4)}\n`;
         }
         output.textContent = lines;
       };

--- a/uke-worklet.js
+++ b/uke-worklet.js
@@ -137,7 +137,15 @@ class UkeProcessor extends AudioWorkletProcessor {
     this._nextUpdateFrame -= channel.length;
     if (this._nextUpdateFrame < 0) {
       this._nextUpdateFrame += this.intervalInFrames;
-      const values = this.uke.values().map(lc => ({ F: lc.F, amp: lc.r }));
+      const values = this.uke.values().map(lc => ({
+        F: lc.F,
+        entropy: lc.cval.re,
+        neg_energy: lc.cval.im,
+        phase: lc.phi,
+        amp: lc.r,
+        onset_amp: lc.phi < 0 ? lc.r : 0,
+        cycle: lc.lifecycle,
+      }));
       this.port.postMessage({ values });
     }
     return true;

--- a/uke_tuner.html
+++ b/uke_tuner.html
@@ -6,6 +6,7 @@
 </head>
 <body>
   <h1>Ukulele Tuner Demo</h1>
+  <pre id="header"></pre>
   <pre id="output"></pre>
   <script src="main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- show receptor header in uke_tuner.html
- display full receptor data (entropy, energy, phase, amplitude, onset and cycle) in `main.js`
- post all receptor values from uke-worklet.js

## Testing
- `node --check main.js`
- `node --check uke-worklet.js`


------
https://chatgpt.com/codex/tasks/task_e_686f10faf69c833399ca4d50400ec02c