### PR TITLE
Add instantaneous frequency and note helpers

### DIFF
--- a/pitch.js
+++ b/pitch.js
@@ -1,0 +1,17 @@
+export function midiNoteFromFreq(freq, A4 = 440.0) {
+  return 12.0 * (Math.log(freq / A4) / Math.log(2)) + 69;
+}
+
+export function noteFromFreq(freq, A4 = 440.0) {
+  const notes = [
+    "C /B#", "C#/Db", "D /D ", "D#/Eb",
+    "E /Fb", "F /E#", "F#/Gb", "G /G ",
+    "G#/Ab", "A /A ", "A#/Bb", "B /Cb"
+  ];
+  const n = midiNoteFromFreq(freq, A4);
+  const intN = Math.floor(n + 0.5);
+  const octave = Math.floor(intN / 12) - 1;
+  const octaveNote = ((intN % 12) + 12) % 12;
+  const cents = 100.0 * (((n + 0.5) % 1) - 0.5);
+  return { note: notes[octaveNote], octave, cents };
+}


### PR DESCRIPTION
## Summary
- compute instantaneous frequency for each sensor in `uke-worklet.js`
- propagate the value in lifecycle output
- expose helper functions `midiNoteFromFreq` and `noteFromFreq` in new `pitch.js`

## Testing
- `node --check uke-worklet.js`
- `node --check pitch.js`
- `node -e "require('./pitch.js')"`

------
https://chatgpt.com/codex/tasks/task_e_68747aea548483338e0eac84e45bccbe